### PR TITLE
Bun production Docker

### DIFF
--- a/epicshop/Dockerfile
+++ b/epicshop/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-bookworm-slim as base
+FROM oven/bun:1-debian as base
 
 RUN apt-get update && apt-get install -y git
 
@@ -18,10 +18,10 @@ RUN git clone --depth 1 ${EPICSHOP_GITHUB_REPO} ${EPICSHOP_CONTEXT_CWD}
 
 ADD . .
 
-RUN npm install --omit=dev
+RUN bun install --production
 
 RUN cd ${EPICSHOP_CONTEXT_CWD} && \
-    npx epicshop warm
+    bunx epicshop warm
 
 CMD cd ${EPICSHOP_CONTEXT_CWD} && \
-    npx epicshop start
+    bunx epicshop start


### PR DESCRIPTION
Update Dockerfile to use Bun instead of Node for production.

---
<a href="https://cursor.com/background-agent?bcId=bc-c26f6be4-6b7d-4e97-9e0d-a8712dfd3915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c26f6be4-6b7d-4e97-9e0d-a8712dfd3915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates the production container to Bun and aligns install/runtime commands accordingly.
> 
> - Change base image to `oven/bun:1-debian` in `epicshop/Dockerfile`
> - Replace `npm install --omit=dev` with `bun install --production`
> - Replace `npx epicshop warm/start` with `bunx epicshop warm/start`
> - Environment variables, repo clone, and workdir flow remain the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8dbaef66e343810e030e94b2a42f4ec06ef7c73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->